### PR TITLE
Fix bug with repeating slashes in URL

### DIFF
--- a/core/common/build.gradle
+++ b/core/common/build.gradle
@@ -13,4 +13,5 @@ dependencies {
     implementation di.koinCore
     implementation reactive.rxjava
     implementation log.timber
+    testImplementation test.junit
 }

--- a/core/common/src/main/java/com/shifthackz/aisdv1/core/common/extensions/StringExtensions.kt
+++ b/core/common/src/main/java/com/shifthackz/aisdv1/core/common/extensions/StringExtensions.kt
@@ -1,6 +1,7 @@
 package com.shifthackz.aisdv1.core.common.extensions
 
 private const val PROTOCOL_DELIMITER = "://"
+private const val PROTOCOL_HOLDER = "[[_PROTOCOL_]]"
 
 fun String.withoutUrlProtocol(): String {
     if (!this.contains(PROTOCOL_DELIMITER)) return this
@@ -8,3 +9,9 @@ fun String.withoutUrlProtocol(): String {
     if (decomposed.size < 2) return this
     return decomposed.last()
 }
+
+fun String.fixUrlSlashes(): String = this
+    .replace(PROTOCOL_DELIMITER, PROTOCOL_HOLDER)
+    .replace(Regex("/{2,}"), "/")
+    .let { str -> if (str.last() == '/') str.substring(0, str.lastIndex) else str }
+    .replace(PROTOCOL_HOLDER, PROTOCOL_DELIMITER)

--- a/core/common/src/test/java/com/shifthackz/aisdv1/core/common/extensions/StringExtensionsTest.kt
+++ b/core/common/src/test/java/com/shifthackz/aisdv1/core/common/extensions/StringExtensionsTest.kt
@@ -1,0 +1,28 @@
+package com.shifthackz.aisdv1.core.common.extensions
+
+import org.junit.Assert
+import org.junit.Test
+
+class StringExtensionsTest {
+
+    @Test
+    fun `given string with slash at and, expected no slash at end`() {
+        val actual = "http://192.168.228.9:7860/".fixUrlSlashes()
+        val expected = "http://192.168.228.9:7860"
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `given string with 3 slashes at and, expected no slashes at end`() {
+        val actual = "http://192.168.228.9:7860///".fixUrlSlashes()
+        val expected = "http://192.168.228.9:7860"
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `given string with even and odd duplicates and slash at end, expected no duplicate slashes and slash at end`() {
+        val actual = "http://192.168.228.9:7860///path1////path2/".fixUrlSlashes()
+        val expected = "http://192.168.228.9:7860/path1/path2"
+        Assert.assertEquals(expected, actual)
+    }
+}

--- a/data/src/main/java/com/shifthackz/aisdv1/data/di/RemoteDataSourceModule.kt
+++ b/data/src/main/java/com/shifthackz/aisdv1/data/di/RemoteDataSourceModule.kt
@@ -1,5 +1,6 @@
 package com.shifthackz.aisdv1.data.di
 
+import com.shifthackz.aisdv1.core.common.extensions.fixUrlSlashes
 import com.shifthackz.aisdv1.core.common.links.LinksProvider
 import com.shifthackz.aisdv1.data.gateway.ServerConnectivityGatewayImpl
 import com.shifthackz.aisdv1.data.provider.ServerUrlProvider
@@ -33,7 +34,10 @@ val remoteDataSourceModule = module {
             val links = get<LinksProvider>()
             val chain = if (prefs.useSdAiCloud) Single.fromCallable(links::cloudUrl)
             else Single.fromCallable(prefs::serverUrl)
-            chain.map { baseUrl -> "$baseUrl/$endpoint" }
+
+            chain
+                .map(String::fixUrlSlashes)
+                .map { baseUrl -> "$baseUrl/$endpoint" }
         }
     }
 

--- a/data/src/main/java/com/shifthackz/aisdv1/data/preference/PreferenceManagerImpl.kt
+++ b/data/src/main/java/com/shifthackz/aisdv1/data/preference/PreferenceManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.shifthackz.aisdv1.data.preference
 
 import android.content.SharedPreferences
+import com.shifthackz.aisdv1.core.common.extensions.fixUrlSlashes
 import com.shifthackz.aisdv1.domain.entity.Settings
 import com.shifthackz.aisdv1.domain.preference.PreferenceManager
 import io.reactivex.rxjava3.core.BackpressureStrategy
@@ -15,10 +16,10 @@ class PreferenceManagerImpl(
         BehaviorSubject.createDefault(Unit)
 
     override var serverUrl: String
-        get() = if (useSdAiCloud) ""
-        else preferences.getString(KEY_SERVER_URL, "") ?: ""
+        get() = (if (useSdAiCloud) "" else preferences.getString(KEY_SERVER_URL, "")
+            ?: "").fixUrlSlashes()
         set(value) = preferences.edit()
-            .putString(KEY_SERVER_URL, if (useSdAiCloud) "" else value)
+            .putString(KEY_SERVER_URL, (if (useSdAiCloud) "" else value).fixUrlSlashes())
             .apply()
             .also { onPreferencesChanged() }
 

--- a/data/src/main/java/com/shifthackz/aisdv1/data/remote/StableDiffusionGenerationRemoteDataSource.kt
+++ b/data/src/main/java/com/shifthackz/aisdv1/data/remote/StableDiffusionGenerationRemoteDataSource.kt
@@ -1,5 +1,6 @@
 package com.shifthackz.aisdv1.data.remote
 
+import com.shifthackz.aisdv1.core.common.extensions.fixUrlSlashes
 import com.shifthackz.aisdv1.data.mappers.mapToAiGenResult
 import com.shifthackz.aisdv1.data.mappers.mapToRequest
 import com.shifthackz.aisdv1.data.provider.ServerUrlProvider
@@ -20,7 +21,7 @@ internal class StableDiffusionGenerationRemoteDataSource(
     override fun checkAvailability() = serverUrlProvider("/")
         .flatMapCompletable(api::healthCheck)
 
-    override fun checkAvailability(url: String) = api.healthCheck(url)
+    override fun checkAvailability(url: String) = api.healthCheck(url.fixUrlSlashes())
 
     override fun textToImage(payload: TextToImagePayload) = serverUrlProvider(PATH_TXT_TO_IMG)
         .flatMap { url -> api.textToImage(url, payload.mapToRequest()) }


### PR DESCRIPTION
### Description
- There was a bug which did not allow to connect to server if URL ends with slash.
- This fix also covers the use case where there is odd or even count of repeating slashes

### Screenshots / Video (Optional)

### Checklist
- [X] I have ensured this PR does not contain any breaking changes for existing functionality;
- [X] I have added automated tests that cover the new behavior and removed obsolete tests and code;

### Tested On
- [X] Emulator
- [X] Real device
