### PR TITLE
Export input image to gallery

### DIFF
--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/gallery/detail/GalleryDetailScreen.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/gallery/detail/GalleryDetailScreen.kt
@@ -3,6 +3,8 @@
 package com.shifthackz.aisdv1.presentation.screen.gallery.detail
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -127,7 +129,11 @@ private fun ScreenContent(
                         )
                     },
                     actions = {
-                        AnimatedVisibility(visible = state.selectedTab != GalleryDetailState.Tab.INFO) {
+                        AnimatedVisibility(
+                            visible = state.selectedTab != GalleryDetailState.Tab.INFO,
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                        ) {
                             IconButton(
                                 onClick = { processIntent(GalleryDetailIntent.Export.Image) },
                                 content = {

--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/gallery/detail/GalleryDetailScreen.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/gallery/detail/GalleryDetailScreen.kt
@@ -2,6 +2,7 @@
 
 package com.shifthackz.aisdv1.presentation.screen.gallery.detail
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -126,17 +127,19 @@ private fun ScreenContent(
                         )
                     },
                     actions = {
-                        IconButton(
-                            onClick = { processIntent(GalleryDetailIntent.Export.Image) },
-                            content = {
-                                Image(
-                                    modifier = Modifier.size(24.dp),
-                                    painter = painterResource(id = R.drawable.ic_share),
-                                    contentDescription = "Export",
-                                    colorFilter = ColorFilter.tint(LocalContentColor.current),
-                                )
-                            },
-                        )
+                        AnimatedVisibility(visible = state.selectedTab != GalleryDetailState.Tab.INFO) {
+                            IconButton(
+                                onClick = { processIntent(GalleryDetailIntent.Export.Image) },
+                                content = {
+                                    Image(
+                                        modifier = Modifier.size(24.dp),
+                                        painter = painterResource(id = R.drawable.ic_share),
+                                        contentDescription = "Export",
+                                        colorFilter = ColorFilter.tint(LocalContentColor.current),
+                                    )
+                                },
+                            )
+                        }
                     }
                 )
             },

--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/gallery/detail/GalleryDetailViewModel.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/gallery/detail/GalleryDetailViewModel.kt
@@ -79,8 +79,17 @@ class GalleryDetailViewModel(
     }
 
     private fun share() {
-        if (currentState !is GalleryDetailState.Content) return
-        !galleryDetailBitmapExporter((currentState as GalleryDetailState.Content).bitmap)
+        val state = currentState as? GalleryDetailState.Content ?: return
+        val bitmap = if (
+            state.generationType == AiGenerationResult.Type.IMAGE_TO_IMAGE
+            && state.inputBitmap != null
+            && state.selectedTab == GalleryDetailState.Tab.ORIGINAL
+        ) {
+            state.inputBitmap
+        } else {
+            state.bitmap
+        }
+        !galleryDetailBitmapExporter(bitmap)
             .subscribeOnMainThread(schedulersProvider)
             .subscribeBy(::errorLog) { file ->
                 emitEffect(GalleryDetailEffect.ShareImageFile(file))


### PR DESCRIPTION
Via [issue](https://github.com/ShiftHackZ/Stable-Diffusion-Android/issues/187)

### Description
- Added option to save input image to gallery from detail when generating via img2img

### Checklist
- [x] I have ensured this PR does not contain any breaking changes for existing functionality;
- [ ] I have added automated tests that cover the new behavior and removed obsolete tests and code.

### Tested On
- [ ] Emulator
- [X] Real device
