### PR TITLE
AndroidKeyStore bug fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locale_config"
+        android:allowBackup="false"
         android:requestLegacyExternalStorage="true"
         android:theme="@style/Theme.AiSdCompose.Splash"
         android:usesCleartextTraffic="true">


### PR DESCRIPTION
### Description
- Fixed crash after deleting and installing app with AndroidKeyStore still backed up

### Checklist
- [x] I have ensured this PR does not contain any breaking changes for existing functionality;
- [ ] I have added automated tests that cover the new behavior and removed obsolete tests and code;

### Tested On
- [ ] Emulator
- [x] Real device
