### PR TITLE
Migrate to android native photo picker approach. 

### DIFF
--- a/app/src/foss/AndroidManifest.xml
+++ b/app/src/foss/AndroidManifest.xml
@@ -7,7 +7,6 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -7,7 +7,6 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,5 +59,15 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
+
+        <service android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false"
+            tools:ignore="MissingClass">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data android:name="photopicker_activity:0:required" android:value="" />
+        </service>
     </application>
 </manifest>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -12,6 +12,8 @@
         name="folder_work"
         path="work/" />
 
+    <cache-path name="cache" path="." />
+
     <external-path name="media" path="." />
     <external-path name="external_files" path="."/>
     <external-path name="external" path="."/>

--- a/app/src/playstore/AndroidManifest.xml
+++ b/app/src/playstore/AndroidManifest.xml
@@ -7,7 +7,6 @@
         android:required="false" />
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ crop = "0.1.1"
 mvi = "1.0.2"
 preferences = "1.0.1"
 dayNightSwitch = "1.0.0"
-imagepicker = "v2.0.3"
 catppuccin = "0.1.2"
 turbine = "1.2.0"
 roboelectric = "4.13"
@@ -108,7 +107,6 @@ compose-gestures = { group = "com.github.SmartToolFactory", name = "Compose-Exte
 compose-crop = { group = "io.github.mr0xf00", name = "easycrop", version.ref = "crop" }
 shifthackz-mvi = { group = "com.github.ShiftHackZ", name = "AndroidCoreMVI", version.ref = "mvi" }
 shifthackz-preferences = { group = "com.github.ShiftHackZ", name = "AndroidPreferences", version.ref = "preferences" }
-shifthackz-imagepicker = { group = "com.github.ShiftHackZ", name = "ImagePicker", version.ref = "imagepicker" }
 shifthackz-daynightswitch = { group = "com.github.ShiftHackZ", name = "DayNightSwitch", version.ref = "dayNightSwitch" }
 shifthackz-catppuccin-legacy = { group = "com.github.ShiftHackZ.Catppuccin-Android-Library", name = "palette-legacy", version.ref = "catppuccin" }
 shifthackz-catppuccin-compose = { group = "com.github.ShiftHackZ.Catppuccin-Android-Library", name = "compose", version.ref = "catppuccin" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(libs.rx.kotlin)
     implementation(libs.rx.android)
 
-    implementation(libs.shifthackz.imagepicker)
     implementation(libs.shifthackz.daynightswitch)
     implementation(libs.shifthackz.catppuccin.compose)
     implementation(libs.shifthackz.catppuccin.splash)

--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/core/GenerationMviIntent.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/core/GenerationMviIntent.kt
@@ -11,7 +11,6 @@ import com.shifthackz.aisdv1.domain.entity.StabilityAiStylePreset
 import com.shifthackz.aisdv1.presentation.model.Modal
 import com.shifthackz.aisdv1.presentation.screen.drawer.DrawerIntent
 import com.shifthackz.android.core.mvi.MviIntent
-import com.shz.imagepicker.imagepicker.model.PickedResult
 
 sealed interface GenerationMviIntent : MviIntent {
 
@@ -109,7 +108,7 @@ sealed interface ImageToImageIntent : GenerationMviIntent {
 
     data class UpdateImage(val bitmap: Bitmap) : ImageToImageIntent
 
-    data class CropImage(val result: PickedResult) : ImageToImageIntent
+    data class CropImage(val bitmap: Bitmap) : ImageToImageIntent
 
     enum class Pick : ImageToImageIntent {
         Camera, Gallery

--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/img2img/ImageToImageViewModel.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/screen/img2img/ImageToImageViewModel.kt
@@ -32,7 +32,6 @@ import com.shifthackz.aisdv1.presentation.model.Modal
 import com.shifthackz.aisdv1.presentation.navigation.router.drawer.DrawerRouter
 import com.shifthackz.aisdv1.presentation.navigation.router.main.MainRouter
 import com.shifthackz.aisdv1.presentation.screen.inpaint.InPaintStateProducer
-import com.shz.imagepicker.imagepicker.model.PickedResult
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.kotlin.subscribeBy
@@ -141,12 +140,8 @@ class ImageToImageViewModel(
 
             ImageToImageIntent.Pick.Gallery -> emitEffect(ImageToImageEffect.GalleryPicker)
 
-            is ImageToImageIntent.CropImage -> when (intent.result) {
-                is PickedResult.Single -> updateState {
-                    it.copy(screenModal = Modal.Image.Crop(intent.result.image.bitmap))
-                }
-
-                else -> Unit
+            is ImageToImageIntent.CropImage -> updateState {
+                it.copy(screenModal = Modal.Image.Crop(intent.bitmap))
             }
 
             is ImageToImageIntent.UpdateImage -> updateState {

--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/utils/PermissionUtil.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/utils/PermissionUtil.kt
@@ -11,7 +11,7 @@ object PermissionUtil {
     fun checkStoragePermission(
         context: Context,
         onLaunch: (missingPermissions: Array<String>) -> Unit = {},
-    ): Boolean  {
+    ): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             return false
         }
@@ -39,6 +39,21 @@ object PermissionUtil {
             ) != PackageManager.PERMISSION_GRANTED
         ) {
             onLaunch(Manifest.permission.POST_NOTIFICATIONS)
+            return false
+        }
+        return true
+    }
+
+    fun checkCameraPermission(
+        context: Context,
+        onLaunch: (missingPermission: String) -> Unit,
+    ): Boolean {
+        if (ActivityCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            onLaunch(Manifest.permission.CAMERA)
             return false
         }
         return true

--- a/presentation/src/main/java/com/shifthackz/aisdv1/presentation/utils/UriToBitmap.kt
+++ b/presentation/src/main/java/com/shifthackz/aisdv1/presentation/utils/UriToBitmap.kt
@@ -1,0 +1,15 @@
+package com.shifthackz.aisdv1.presentation.utils
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import com.shifthackz.aisdv1.core.common.log.errorLog
+
+fun uriToBitmap(context: Context, uri: Uri): Bitmap? = try {
+    val inputStream = context.contentResolver.openInputStream(uri)
+    BitmapFactory.decodeStream(inputStream).also { inputStream?.close() }
+} catch (e: Exception) {
+    errorLog("UrlToBitmap", e)
+    null
+}


### PR DESCRIPTION
### Description
- Migrate to android native photo picker approach. 
- Deprecate usage of READ_MEDIA_IMAGES permission.

### Screenshots / Video (Optional)

### Checklist
- [ ] I have ensured this PR does not contain any breaking changes for existing functionality;
- [ ] I have added automated tests that cover the new behavior and removed obsolete tests and code;

### Tested On
- [X] Emulator
- [x] Real device
